### PR TITLE
lavc:vaapi dec : fix output yuv error on particular driver by use vaa…

### DIFF
--- a/libavutil/hwcontext_vaapi.c
+++ b/libavutil/hwcontext_vaapi.c
@@ -714,7 +714,7 @@ static int vaapi_map_frame(AVHWFramesContext *hwfc,
     // assume for now that the user is not aware of that and would therefore
     // prefer not to be given direct-mapped memory if they request read access.
     if (ctx->derive_works &&
-        ((flags & VAAPI_MAP_DIRECT) || !(flags & VAAPI_MAP_READ))) {
+        ((flags & VAAPI_MAP_DIRECT) || !(flags & VAAPI_MAP_READ) || (dst->format == AV_PIX_FMT_NV12))) {
         vas = vaDeriveImage(hwctx->display, surface_id, &map->image);
         if (vas != VA_STATUS_SUCCESS) {
             av_log(hwfc, AV_LOG_ERROR, "Failed to derive image from "


### PR DESCRIPTION
…pi decoder.

when vaapi decoder run on particular driver that only support nv12
output format, output yuv will showed blurred screen.

in the test bed with the test command:
ffmpeg -y -hwaccel vaapi -hwaccel_device /dev/dri/card0 -i \
blue_sky_1080p.h264 out.yuv

fps: 32

Signed-off-by: TangZhiZhen zhizhen.tang@intel.com
