### PR TITLE
lavc:vaapi dec:speed up copy the YUV data from the USWC to the memory.

### DIFF
--- a/libavutil/Makefile
+++ b/libavutil/Makefile
@@ -53,6 +53,7 @@ HEADERS = adler32.h                                                     \
           parseutils.h                                                  \
           pixdesc.h                                                     \
           pixelutils.h                                                  \
+          fastcopy.h                                                    \
           pixfmt.h                                                      \
           random_seed.h                                                 \
           rc4.h                                                         \
@@ -131,6 +132,7 @@ OBJS = adler32.o                                                        \
        parseutils.o                                                     \
        pixdesc.o                                                        \
        pixelutils.o                                                     \
+       fastcopy.o                                                       \
        random_seed.o                                                    \
        rational.o                                                       \
        reverse.o                                                        \

--- a/libavutil/fastcopy.c
+++ b/libavutil/fastcopy.c
@@ -1,0 +1,49 @@
+/*
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FFmpeg; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "config.h"
+#include "common.h"
+#include "fastcopy.h"
+#include "internal.h"
+
+#if CONFIG_VAAPI
+
+#include "x86/fastcopy.h"
+
+static FastCopyAccel fastcopyaccel = {NULL, 0, 0, 0};
+
+#endif
+
+void av_fastcopy_uswc_init()
+{
+#if CONFIG_VAAPI
+#if ARCH_X86
+    ff_fastcopy_uswc_init_x86(&fastcopyaccel);
+#endif
+#endif
+}
+
+
+FastCopyAccel *av_fastcopy_uswc_get_fn()
+{
+#if !CONFIG_VAAPI
+    return NULL;
+#else
+    return &fastcopyaccel;
+#endif
+}

--- a/libavutil/fastcopy.h
+++ b/libavutil/fastcopy.h
@@ -1,0 +1,39 @@
+/*
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FFmpeg; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef AVUTIL_FASTCOPY_H
+#define AVUTIL_FASTCOPY_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include "common.h"
+
+typedef void (*av_fastcopy_uswc_fn)(void *dst, void *src, size_t size);
+
+typedef struct FastCopyAccel {
+    av_fastcopy_uswc_fn fastcopy_fn;
+    int register_bits;
+    int align_bits;
+    int offset_bits;
+} FastCopyAccel;
+
+void av_fastcopy_uswc_init();
+
+FastCopyAccel *av_fastcopy_uswc_get_fn();
+
+#endif

--- a/libavutil/x86/Makefile
+++ b/libavutil/x86/Makefile
@@ -3,6 +3,7 @@ OBJS += x86/cpu.o                                                       \
         x86/float_dsp_init.o                                            \
         x86/lls_init.o                                                  \
 
+OBJS-$(CONFIG_VAAPI) += x86/fastcopy_init.o
 OBJS-$(CONFIG_PIXELUTILS) += x86/pixelutils_init.o                      \
 
 EMMS_OBJS_$(HAVE_MMX_INLINE)_$(HAVE_MMX_EXTERNAL)_$(HAVE_MM_EMPTY) = x86/emms.o
@@ -13,4 +14,5 @@ YASM-OBJS += x86/cpuid.o                                                \
              x86/float_dsp.o                                            \
              x86/lls.o                                                  \
 
+YASM-OBJS-$(CONFIG_VAAPI) += x86/fastcopy.o
 YASM-OBJS-$(CONFIG_PIXELUTILS) += x86/pixelutils.o                      \

--- a/libavutil/x86/fastcopy.asm
+++ b/libavutil/x86/fastcopy.asm
@@ -1,0 +1,43 @@
+%include "libavutil/x86/x86util.asm"
+
+SECTION .text
+
+;-------------------------------------------------------------------------------
+; void ff_lock_unlock_mem_from_uswc();
+;-------------------------------------------------------------------------------
+cglobal lock_unlock_mem_from_uswc , 0, 0, 0
+    mfence
+    RET
+
+;-------------------------------------------------------------------------------
+; void ff_copy_mem_from_uswc_sse4(void *dst, void *src, 
+;                                 size_t len);
+;-------------------------------------------------------------------------------
+%if HAVE_SSE4_EXTERNAL
+INIT_XMM sse4
+cglobal copy_mem_from_uswc, 3, 3, 1, dst, src, len
+%assign i 0
+%rep 8
+    movntdqa m0, [srcq+i*mmsize]
+    movdqa[dstq+i*mmsize], m0
+%assign i i+1
+%endrep
+    RET
+%endif
+
+;-------------------------------------------------------------------------------
+; void ff_copy_mem_from_uswc_avx(void *dst, void *src,
+;                                size_t len);
+;-------------------------------------------------------------------------------
+%if HAVE_AVX_EXTERNAL
+INIT_YMM avx
+cglobal copy_mem_from_uswc, 3, 3, 1, dst, src, len
+%assign i 0
+%rep 8
+    vmovntdqa m0, [srcq+i*mmsize]
+    vmovdqa[dstq+i*mmsize], m0
+%assign i i+1
+%endrep
+    RET
+%endif
+

--- a/libavutil/x86/fastcopy.h
+++ b/libavutil/x86/fastcopy.h
@@ -1,0 +1,26 @@
+/*
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FFmpeg; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef AVUTIL_X86_FASTCOPY_H
+#define AVUTIL_X86_FASTCOPY_H
+
+#include "libavutil/fastcopy.h"
+
+void ff_fastcopy_uswc_init_x86(FastCopyAccel *fc);
+
+#endif

--- a/libavutil/x86/fastcopy_init.c
+++ b/libavutil/x86/fastcopy_init.c
@@ -1,0 +1,46 @@
+/*
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FFmpeg; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "config.h"
+
+#include "fastcopy.h"
+#include "cpu.h"
+
+void *ff_copy_mem_from_uswc_avx(void *dst, void *src, size_t size);
+
+void *ff_copy_mem_from_uswc_sse4(void *dst, void *src, size_t size);
+
+void ff_fastcopy_uswc_init_x86(FastCopyAccel *fc)
+{
+    int cpu_flags = av_get_cpu_flags();
+
+    if (EXTERNAL_SSE4(cpu_flags)) {
+        fc->fastcopy_fn = ff_copy_mem_from_uswc_sse4;
+        fc->register_bits = 128;
+        fc->align_bits = 0x0F;
+        fc->offset_bits = 7;
+    }
+
+    if (EXTERNAL_AVX(cpu_flags)) {
+        fc->fastcopy_fn = ff_copy_mem_from_uswc_avx;
+        fc->register_bits = 256;
+        fc->align_bits = 0x1F;
+        fc->offset_bits = 8;
+    }
+
+}


### PR DESCRIPTION
Firstly, it will copy the yuv data from the USWC to the memory by use CPU
instruction acceleration, such as sse4, avx. Secondly, make a copy of the
memory. This method will make the speed more than 10 times.

in the test bed with the test command:
ffmpeg -y -hwaccel vaapi -hwaccel_device /dev/dri/card0 -i \
skyfall2-trailer.mp4 -an -f null /dev/null

fps: 500

when vaapi decoder run on particular driver that only support nv12
output format, output yuv will showed blurred screen.

in the test bed with the test command:
ffmpeg -y -hwaccel vaapi -hwaccel_device /dev/dri/card0 -i \
skyfall2-trailer.mp4 -an out.yuv

fps: 50

Signed-off-by: TangZhiZhen zhizhen.tang@intel.com
