### PR TITLE
lavc:vaapi dec:speed up vaapi decoder.

### DIFF
--- a/ffmpeg_opt.c
+++ b/ffmpeg_opt.c
@@ -747,6 +747,8 @@ static void add_input_streams(OptionsContext *o, AVFormatContext *ic)
                     ist->hwaccel_id = HWACCEL_AUTO;
                 else {
                     int i;
+                    if (!strcmp(hwaccel, "vaapi"))
+                        ist->resample_pix_fmt = AV_PIX_FMT_NV12;
                     for (i = 0; hwaccels[i].name; i++) {
                         if (!strcmp(hwaccels[i].name, hwaccel)) {
                             ist->hwaccel_id = hwaccels[i].id;

--- a/libavutil/Makefile
+++ b/libavutil/Makefile
@@ -53,6 +53,7 @@ HEADERS = adler32.h                                                     \
           parseutils.h                                                  \
           pixdesc.h                                                     \
           pixelutils.h                                                  \
+          fastcopy.h                                                    \
           pixfmt.h                                                      \
           random_seed.h                                                 \
           rc4.h                                                         \
@@ -131,6 +132,7 @@ OBJS = adler32.o                                                        \
        parseutils.o                                                     \
        pixdesc.o                                                        \
        pixelutils.o                                                     \
+       fastcopy.o                                                       \
        random_seed.o                                                    \
        rational.o                                                       \
        reverse.o                                                        \

--- a/libavutil/fastcopy.c
+++ b/libavutil/fastcopy.c
@@ -1,0 +1,49 @@
+/*
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FFmpeg; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "config.h"
+#include "common.h"
+#include "fastcopy.h"
+#include "internal.h"
+
+#if CONFIG_VAAPI
+
+#include "x86/fastcopy.h"
+
+static FastCopyAccel fastcopyaccel = {NULL, 0, 0, 0};
+
+#endif
+
+void av_fastcopy_uswc_init()
+{
+#if CONFIG_VAAPI
+#if ARCH_X86
+    ff_fastcopy_uswc_init_x86(&fastcopyaccel);
+#endif
+#endif
+}
+
+
+FastCopyAccel *av_fastcopy_uswc_get_fn()
+{
+#if !CONFIG_VAAPI
+    return NULL;
+#else
+    return &fastcopyaccel;
+#endif
+}

--- a/libavutil/fastcopy.h
+++ b/libavutil/fastcopy.h
@@ -1,0 +1,39 @@
+/*
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FFmpeg; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef AVUTIL_FASTCOPY_H
+#define AVUTIL_FASTCOPY_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include "common.h"
+
+typedef void (*av_fastcopy_uswc_fn)(void *dst, void *src, size_t size);
+
+typedef struct FastCopyAccel {
+    av_fastcopy_uswc_fn fastcopy_fn;
+    int register_bits;
+    int align_bits;
+    int offset_bits;
+} FastCopyAccel;
+
+void av_fastcopy_uswc_init();
+
+FastCopyAccel *av_fastcopy_uswc_get_fn();
+
+#endif

--- a/libavutil/hwcontext_vaapi.c
+++ b/libavutil/hwcontext_vaapi.c
@@ -40,6 +40,9 @@
 #include "mem.h"
 #include "pixdesc.h"
 #include "pixfmt.h"
+#include "fastcopy.h"
+
+extern void ff_lock_unlock_mem_from_uswc();
 
 typedef struct VAAPIDevicePriv {
 #if HAVE_VAAPI_X11
@@ -341,6 +344,8 @@ static int vaapi_device_init(AVHWDeviceContext *hwdev)
             av_log(hwdev, AV_LOG_DEBUG, "Format %#x -> unknown.\n", fourcc);
         }
     }
+
+    av_fastcopy_uswc_init();
 
     av_free(image_list);
     av_hwframe_constraints_free(&constraints);
@@ -662,6 +667,55 @@ static void vaapi_unmap_frame(void *opaque, uint8_t *data)
     av_free(map);
 }
 
+static void *vaapi_copy_from_uswc(void *dst, void *src, size_t size)
+{
+    char aligned;
+    int remain, i, round;
+    uint8_t *pdst, *psrc;
+    FastCopyAccel *fc = NULL;
+
+    if (dst == NULL || src == NULL || size == 0) {
+        return NULL;
+    }
+
+    fc = av_fastcopy_uswc_get_fn();
+
+    // If doesn't support instruction acceleration,  We would like to
+    // choose memcpy.
+    if (fc == NULL || fc->fastcopy_fn == NULL) {
+        return memcpy(dst, src, size);
+    }
+
+    aligned = (((size_t) dst) | ((size_t) src)) & fc->align_bits;
+
+    if (aligned != 0) {
+        return NULL;
+    }
+
+    pdst = (uint8_t *) dst;
+    psrc = (uint8_t *) src;
+    remain = size & (fc->register_bits - 1);
+    round = size >> (fc->offset_bits);
+
+    ff_lock_unlock_mem_from_uswc();
+
+    for (i = 0; i < round; i++) {
+        fc->fastcopy_fn(pdst, psrc, fc->register_bits);
+        psrc += fc->register_bits;
+        pdst += fc->register_bits;
+    }
+
+    ff_lock_unlock_mem_from_uswc();
+
+    // We would like to use memcpy to copy a small number of bytes
+    // that are not aligned
+    if (remain > 0) {
+        memcpy(pdst, psrc, remain);
+    }
+
+    return dst;
+}
+
 static int vaapi_map_frame(AVHWFramesContext *hwfc,
                            AVFrame *dst, const AVFrame *src, int flags)
 {
@@ -672,7 +726,7 @@ static int vaapi_map_frame(AVHWFramesContext *hwfc,
     VAAPISurfaceMap *map;
     VAStatus vas;
     void *address = NULL;
-    int err, i;
+    int err, i, plane_size;
 
     surface_id = (VASurfaceID)(uintptr_t)src->data[3];
     av_log(hwfc, AV_LOG_DEBUG, "Map surface %#x.\n", surface_id);
@@ -718,7 +772,7 @@ static int vaapi_map_frame(AVHWFramesContext *hwfc,
     // assume for now that the user is not aware of that and would therefore
     // prefer not to be given direct-mapped memory if they request read access.
     if (ctx->derive_works &&
-        ((flags & VAAPI_MAP_DIRECT) || !(flags & VAAPI_MAP_READ))) {
+        ((flags & VAAPI_MAP_DIRECT) || !(flags & VAAPI_MAP_READ) || (dst->format == AV_PIX_FMT_NV12))) {
         vas = vaDeriveImage(hwctx->display, surface_id, &map->image);
         if (vas != VA_STATUS_SUCCESS) {
             av_log(hwfc, AV_LOG_ERROR, "Failed to derive image from "
@@ -769,8 +823,13 @@ static int vaapi_map_frame(AVHWFramesContext *hwfc,
     dst->width  = src->width;
     dst->height = src->height;
 
+    plane_size = map->image.data_size;
+    dst->opaque = av_malloc(FFMAX(map->image.width * map->image.height * 3, plane_size));
+
+    vaapi_copy_from_uswc((void *)dst->opaque, (void *)address, plane_size);
+
     for (i = 0; i < map->image.num_planes; i++) {
-        dst->data[i] = (uint8_t*)address + map->image.offsets[i];
+        dst->data[i] = (uint8_t*)dst->opaque + map->image.offsets[i];
         dst->linesize[i] = map->image.pitches[i];
     }
     if (
@@ -823,6 +882,7 @@ static int vaapi_transfer_data_from(AVHWFramesContext *hwfc,
 
     err = 0;
 fail:
+    av_free(map->opaque);
     av_frame_free(&map);
     return err;
 }

--- a/libavutil/hwcontext_vaapi.c
+++ b/libavutil/hwcontext_vaapi.c
@@ -442,7 +442,11 @@ static int vaapi_frames_init(AVHWFramesContext *hwfc)
     }
 
     if (!hwfc->pool) {
+#ifdef VPG_DRIVER
+        int need_memory_type = 0, need_pixel_format = 1;
+#else
         int need_memory_type = 1, need_pixel_format = 1;
+#endif
         for (i = 0; i < avfc->nb_attributes; i++) {
             if (ctx->attributes[i].type == VASurfaceAttribMemoryType)
                 need_memory_type  = 0;

--- a/libavutil/x86/Makefile
+++ b/libavutil/x86/Makefile
@@ -3,6 +3,7 @@ OBJS += x86/cpu.o                                                       \
         x86/float_dsp_init.o                                            \
         x86/lls_init.o                                                  \
 
+OBJS-$(CONFIG_VAAPI) += x86/fastcopy_init.o
 OBJS-$(CONFIG_PIXELUTILS) += x86/pixelutils_init.o                      \
 
 EMMS_OBJS_$(HAVE_MMX_INLINE)_$(HAVE_MMX_EXTERNAL)_$(HAVE_MM_EMPTY) = x86/emms.o
@@ -13,4 +14,5 @@ YASM-OBJS += x86/cpuid.o                                                \
              x86/float_dsp.o                                            \
              x86/lls.o                                                  \
 
+YASM-OBJS-$(CONFIG_VAAPI) += x86/fastcopy.o
 YASM-OBJS-$(CONFIG_PIXELUTILS) += x86/pixelutils.o                      \

--- a/libavutil/x86/fastcopy.asm
+++ b/libavutil/x86/fastcopy.asm
@@ -1,0 +1,43 @@
+%include "libavutil/x86/x86util.asm"
+
+SECTION .text
+
+;-------------------------------------------------------------------------------
+; void ff_lock_unlock_mem_from_uswc();
+;-------------------------------------------------------------------------------
+cglobal lock_unlock_mem_from_uswc , 0, 0, 0
+    mfence
+    RET
+
+;-------------------------------------------------------------------------------
+; void ff_copy_mem_from_uswc_sse4(void *dst, void *src, 
+;                                 size_t len);
+;-------------------------------------------------------------------------------
+%if HAVE_SSE4_EXTERNAL
+INIT_XMM sse4
+cglobal copy_mem_from_uswc, 3, 3, 1, dst, src, len
+%assign i 0
+%rep 8
+    movntdqa m0, [srcq+i*mmsize]
+    movdqa[dstq+i*mmsize], m0
+%assign i i+1
+%endrep
+    RET
+%endif
+
+;-------------------------------------------------------------------------------
+; void ff_copy_mem_from_uswc_avx(void *dst, void *src,
+;                                size_t len);
+;-------------------------------------------------------------------------------
+%if HAVE_AVX_EXTERNAL
+INIT_YMM avx
+cglobal copy_mem_from_uswc, 3, 3, 1, dst, src, len
+%assign i 0
+%rep 8
+    vmovntdqa m0, [srcq+i*mmsize]
+    vmovdqa[dstq+i*mmsize], m0
+%assign i i+1
+%endrep
+    RET
+%endif
+

--- a/libavutil/x86/fastcopy.h
+++ b/libavutil/x86/fastcopy.h
@@ -1,0 +1,26 @@
+/*
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FFmpeg; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef AVUTIL_X86_FASTCOPY_H
+#define AVUTIL_X86_FASTCOPY_H
+
+#include "libavutil/fastcopy.h"
+
+void ff_fastcopy_uswc_init_x86(FastCopyAccel *fc);
+
+#endif

--- a/libavutil/x86/fastcopy_init.c
+++ b/libavutil/x86/fastcopy_init.c
@@ -1,0 +1,46 @@
+/*
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FFmpeg; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "config.h"
+
+#include "fastcopy.h"
+#include "cpu.h"
+
+void *ff_copy_mem_from_uswc_avx(void *dst, void *src, size_t size);
+
+void *ff_copy_mem_from_uswc_sse4(void *dst, void *src, size_t size);
+
+void ff_fastcopy_uswc_init_x86(FastCopyAccel *fc)
+{
+    int cpu_flags = av_get_cpu_flags();
+
+    if (EXTERNAL_SSE4(cpu_flags)) {
+        fc->fastcopy_fn = ff_copy_mem_from_uswc_sse4;
+        fc->register_bits = 128;
+        fc->align_bits = 0x0F;
+        fc->offset_bits = 7;
+    }
+
+    if (EXTERNAL_AVX(cpu_flags)) {
+        fc->fastcopy_fn = ff_copy_mem_from_uswc_avx;
+        fc->register_bits = 256;
+        fc->align_bits = 0x1F;
+        fc->offset_bits = 8;
+    }
+
+}


### PR DESCRIPTION
vaapi decoder default output format is nv12, it uses the nv12
output format is the fastest than uses the yuv420p output format.
resample to yuv420p will reduce vaapi decoder performance.

in the test bed with the test command:
ffmpeg -y -hwaccel vaapi -hwaccel_device /dev/dri/card0 -stream_loop 10 \
-i skyfall2-trailer.mp4 -an -f null /dev/null

fps: 610
