### PR TITLE
lavc:vaapi dec:speed up vaapi decoder.

### DIFF
--- a/ffmpeg_opt.c
+++ b/ffmpeg_opt.c
@@ -747,6 +747,10 @@ static void add_input_streams(OptionsContext *o, AVFormatContext *ic)
                     ist->hwaccel_id = HWACCEL_AUTO;
                 else {
                     int i;
+                    //vaapi decoder default output format is nv12, set default values
+                    //to get the fastest speed.
+                    if (!strcmp(hwaccel, "vaapi"))
+                        ist->resample_pix_fmt = AV_PIX_FMT_NV12;
                     for (i = 0; hwaccels[i].name; i++) {
                         if (!strcmp(hwaccels[i].name, hwaccel)) {
                             ist->hwaccel_id = hwaccels[i].id;


### PR DESCRIPTION
vaapi decoder default output format is nv12, it uses the nv12
output format is the fastest than uses the yuv420p output format.
resample to yuv420p will reduce vaapi decoder performance.

in the test bed with the test command:
ffmpeg -y -hwaccel vaapi -hwaccel_device /dev/dri/card0 -stream_loop 10 \
-i skyfall2-trailer.mp4 -an -f null /dev/null

fps: 610
