### PR TITLE
lavc:vaapi dec:fix run vaapi decoder base on vpg driver will report

### DIFF
--- a/libavutil/hwcontext_vaapi.c
+++ b/libavutil/hwcontext_vaapi.c
@@ -447,7 +447,12 @@ static int vaapi_frames_init(AVHWFramesContext *hwfc)
     }
 
     if (!hwfc->pool) {
+#ifdef VPG_DRIVER
+        // it can't support VA_SURFACE_ATTRIB_MEM_TYPE_VA on VPG driver.
+        int need_memory_type = 0, need_pixel_format = 1;
+#else
         int need_memory_type = 1, need_pixel_format = 1;
+#endif
         for (i = 0; i < avfc->nb_attributes; i++) {
             if (ctx->attributes[i].type == VASurfaceAttribMemoryType)
                 need_memory_type  = 0;


### PR DESCRIPTION
invalid parameter.

vpg driver can't support surface attribute type is VASurfaceAttribMemoryType
and its value is VA_SURFACE_ATTRIB_MEM_TYPE_VA.

in the test bed with the build command:
./configure --enable-vaapi --extra-cflags=-DVPG_DRIVER

in the test bed with the test command:
ffmpeg -y -hwaccel vaapi -hwaccel_device /dev/dri/card0 -i \
skyfall2-trailer.mp4 -an -f null /dev/null

fps: 610
