### PR TITLE
lavc:vaapi dec:fix vaapi encoder query surface attributes error on

### DIFF
--- a/libavutil/hwcontext_vaapi.c
+++ b/libavutil/hwcontext_vaapi.c
@@ -194,9 +194,14 @@ static int vaapi_frames_get_constraints(AVHWDeviceContext *hwdev,
     }
 
     attr_count = 0;
+    //ignored when funcion vaQuerySurfaceAttributes return 
+    //VA_STATUS_ERROR_UNIMPLEMENTED on VPG driver.
     vas = vaQuerySurfaceAttributes(hwctx->display, config->config_id,
                                    0, &attr_count);
-    if (vas != VA_STATUS_SUCCESS) {
+    if (vas == VA_STATUS_ERROR_UNIMPLEMENTED) {
+        av_log(hwdev, AV_LOG_WARNING,
+               "Query surface attributes isn't implemented.\n");
+    } else if (vas != VA_STATUS_SUCCESS) {
         av_log(hwdev, AV_LOG_ERROR, "Failed to query surface attributes: "
                "%d (%s).\n", vas, vaErrorStr(vas));
         err = AVERROR(ENOSYS);
@@ -211,7 +216,10 @@ static int vaapi_frames_get_constraints(AVHWDeviceContext *hwdev,
 
     vas = vaQuerySurfaceAttributes(hwctx->display, config->config_id,
                                    attr_list, &attr_count);
-    if (vas != VA_STATUS_SUCCESS) {
+    if (vas == VA_STATUS_ERROR_UNIMPLEMENTED) {
+        av_log(hwdev, AV_LOG_WARNING,
+               "Query surface attributes isn't implemented.\n");
+    } else if (vas != VA_STATUS_SUCCESS) {
         av_log(hwdev, AV_LOG_ERROR, "Failed to query surface attributes: "
                "%d (%s).\n", vas, vaErrorStr(vas));
         err = AVERROR(ENOSYS);


### PR DESCRIPTION
VPG driver.

VPG driver doesn't implement vaQuerySurfaceAttributes function, it
will return VA_STATUS_ERROR_UNIMPLEMENTED, ignore this return value.

in the test bed with the test command:
ffmpeg_g -y -vaapi_device /dev/dri/card0 -hwaccel vaapi \
-hwaccel_output_format vaapi -i skyfall2-trailer.mp4 \
-vf 'format=nv12|vaapi,hwupload' -c:v h264_vaapi -an -qp 26 \
output.ts

fps: 150
