### PR TITLE
lavc:vaapi enc:Enable multi-thread encoder to get a higher performance.

### DIFF
--- a/ffmpeg_opt.c
+++ b/ffmpeg_opt.c
@@ -118,6 +118,7 @@ int print_stats       = -1;
 int qp_hist           = 0;
 int stdin_interaction = 1;
 int frame_bits_per_raw_sample = 0;
+int do_multi_thread_encode    = 0;
 float max_error_rate  = 2.0/3;
 
 
@@ -3423,6 +3424,8 @@ const OptionDef options[] = {
     { "hwaccel_output_format", OPT_VIDEO | OPT_STRING | HAS_ARG | OPT_EXPERT |
                           OPT_SPEC | OPT_INPUT,                                  { .off = OFFSET(hwaccel_output_formats) },
         "select output format used with HW accelerated decoding", "format" },
+    { "multi_thread_encode",   OPT_VIDEO | OPT_BOOL,                             {    &do_multi_thread_encode},
+        "launch multi_thread encode except for vcodec copy" },
 #if CONFIG_VDA || CONFIG_VIDEOTOOLBOX
     { "videotoolbox_pixfmt", HAS_ARG | OPT_STRING | OPT_EXPERT, { &videotoolbox_pixfmt}, "" },
 #endif


### PR DESCRIPTION
enable multi-thread encoder at ffmpeg.c, use parameter -multi_thread_encode
to launch multi-thread encoder.

in the test bed with the test command:
ffmpeg_g -y -vaapi_device /dev/dri/card0 -hwaccel vaapi \
-hwaccel_output_format vaapi -i skyfall2-trailer.mp4 \
-vf 'format=nv12|vaapi,hwupload' -c:v h264_vaapi -an -qp 26 \
-multi_thread_encode output.ts

fps: 170
