### PR TITLE
lavc : fix flush data cannot push into in_queue bug.

### DIFF
--- a/libavcodec/libyami_internal.h
+++ b/libavcodec/libyami_internal.h
@@ -112,7 +112,7 @@ int ff_yami_push_data (YamiThreadContext<T> *ctx, T t)
 {
     if (!ctx || !ctx->in_queue)
         return -1;
-    while (ctx->status < YAMI_THREAD_GOT_EOS) {
+    while (ctx->status < YAMI_THREAD_EXIT) {
         /* need enque eos buffer more than once */
         pthread_mutex_lock(&ctx->in_queue_lock);
         if (ctx->in_queue->size() < ctx->max_queue_size) {


### PR DESCRIPTION
fix when flushing data cannot push into in_queue bug.

Signed-off-by: Yun Zhou <yunx.z.zhou@intel.com>